### PR TITLE
http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2012,7 +2012,7 @@ class S3
 		// Convert null query string parameters to strings and sort
 		$parameters = array_map('strval', $parameters); 
 		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
-		$queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
+		$queryString = http_build_query($parameters, '' /* $numeric_prefix */, '&', PHP_QUERY_RFC3986);
 
 		// Payload
 		$amzPayload = array($method);


### PR DESCRIPTION
Pass an empty string (the default value) instead // https://www.php.net/http_build_query

Fixes #33