### PR TITLE
Compatibility with PHP 8.2

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2007,11 +2007,11 @@ class S3
 			$combinedHeaders[strtolower($k)] = trim($v);
 		foreach ($amzHeaders as $k => $v) 
 			$combinedHeaders[strtolower($k)] = trim($v);
-		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
+		uksort($combinedHeaders, array('S3', '__sortMetaHeadersCmp'));
 
 		// Convert null query string parameters to strings and sort
 		$parameters = array_map('strval', $parameters); 
-		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		uksort($parameters, array('S3', '__sortMetaHeadersCmp'));
 		$queryString = http_build_query($parameters, '' /* $numeric_prefix */, '&', PHP_QUERY_RFC3986);
 
 		// Payload


### PR DESCRIPTION
Resolved the deprecation issue

Deprecated: Use of "self" in callables is deprecated in /var/www/html/test/vendor/elecena/amazon-s3-php-class/S3.php on line 2010
Deprecated: Use of "self" in callables is deprecated in /var/www/html/test/vendor/elecena/amazon-s3-php-class/S3.php on line 2014